### PR TITLE
Enable churn collection by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ upjs-plato -r -p ./app1 -T 20 -d report ./app1/src
 
 - Complexity from [typhonjs-escomplex](https://github.com/typhonjs-node-escomplex/typhonjs-escomplex)
 - Lint data from [eslint](http://eslint.org/)
+- Churn data from [git-churn-js](https://github.com/upgradejs/git-churn-js), collected automatically when the analyzed directory is inside a git repository. Use `-g` to point at a different repo (e.g. monorepos with nested `.git` directories), or expect churn to be silently skipped if no git repo is found.
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ Usage : upjs-plato [options] -d <output_dir> <input files>
       Specify a Babel configuration file for project parsing
   -p, --projectRoot : String
       Root directory of the project to analyze. Needed to run audit/outdated/depngn analysis. Must contain a "lock" file with the project's dependencies. If omitted, defaults to the current working directory.
+  -g, --gitPath : String
+      Path to the folder containing the .git directory used for churn collection. If omitted, defaults to the project root. Useful for monorepos with nested git repositories. If the path is not a git repo, churn is silently skipped.
 ```
 
 **Examples**

--- a/lib/assets/scripts/plato-overview.js
+++ b/lib/assets/scripts/plato-overview.js
@@ -262,8 +262,8 @@ $(function() {
 					return {
 						name: report.info.fileShort,
 						x: report.churn,
-						y: report.complexity.aggregate.complexity.cyclomatic,
-						color: COLOR[getRating(report.complexity.aggregate.complexity.cyclomatic)],
+						y: report.complexity.aggregate.cyclomatic,
+						color: COLOR[getRating(report.complexity.aggregate.cyclomatic)],
 						link: report.info.link
 					};
 				})

--- a/lib/plato.js
+++ b/lib/plato.js
@@ -86,8 +86,16 @@ async function inspect(files, outputDir, options, done) {
 
 	console.log('Processing ',files.length, ' files');
 
+	if (!options.projectRoot) {
+		options.projectRoot = process.cwd();
+	}
+
+	if (!options.gitPath) {
+		options.gitPath = options.projectRoot;
+	}
+
 	var flags = {
-		churn: ('gitPath' in options),
+		churn: true,
 		complexity: {
 			sourceType: 'module',
 			ecmaVersion: 6,
@@ -140,11 +148,11 @@ async function inspect(files, outputDir, options, done) {
 	var gitChurn = null;
 
 	if (flags.churn) {
-		gitChurn = new GitChurn({ directory: options.gitPath });
-	}
-
-	if (!options.projectRoot) {
-		options.projectRoot = process.cwd();
+		try {
+			gitChurn = new GitChurn({ directory: options.gitPath });
+		} catch (e) {
+			log.warning('Skipping churn collection for "%s" (not a git repo or git unavailable): %s', options.gitPath, e.message);
+		}
 	}
 
 	const dependencyReportsPromise = options.projectRoot
@@ -198,9 +206,15 @@ async function inspect(files, outputDir, options, done) {
 
 			var filePath = path.resolve(report.info.file);
 
-			var churn = gitChurn && gitChurn.getByPath(filePath);
-			if (churn) {
-				report.churn = churn;
+			if (gitChurn) {
+				try {
+					var churn = gitChurn.getByPath(filePath);
+					if (churn) {
+						report.churn = churn;
+					}
+				} catch (e) {
+					// File isn't tracked in git history — leave churn unset.
+				}
 			}
 			var error = false;
 			await Promise.all(_.map(perFileReporters, async function processReporter(reporter, name) {

--- a/test/plato_churn_test.js
+++ b/test/plato_churn_test.js
@@ -1,0 +1,69 @@
+'use strict';
+
+var test = require('node:test');
+var assert = require('node:assert');
+var fs = require('node:fs');
+var os = require('node:os');
+var path = require('node:path');
+
+var plato = require('../lib/plato');
+
+var projectRoot = path.resolve(__dirname, '..');
+var fixture = path.join('test', 'fixtures', 'a.js');
+var isGitRepo = fs.existsSync(path.join(projectRoot, '.git'));
+
+test('churn is collected by default when no gitPath is provided', { skip: !isGitRepo && 'requires a git checkout' }, function(t, done) {
+	plato.inspect([fixture], null, {}, function(reports) {
+		assert.strictEqual(reports.length, 1);
+		var report = reports[0];
+		assert.ok(report.churn, 'report.churn should be set for a tracked file');
+		assert.ok(report.churn.changes > 0, 'report.churn.changes should be > 0 for a tracked file');
+
+		var overview = plato.getOverviewReport(reports);
+		assert.ok(overview.summary.total.churn > 0, 'overview total.churn should be > 0');
+		done();
+	});
+});
+
+test('plato does not crash when gitPath is not a git repo', function(t, done) {
+	var tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'plato-nogit-'));
+	t.after(function() {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	plato.inspect([fixture], null, { gitPath: tmpDir, projectRoot: tmpDir }, function(reports) {
+		assert.strictEqual(reports.length, 1);
+		assert.strictEqual(reports[0].churn, undefined, 'no churn expected when gitPath is not a git repo');
+
+		var overview = plato.getOverviewReport(reports);
+		assert.strictEqual(overview.summary.total.churn, 0);
+		done();
+	});
+});
+
+test('files outside git history do not crash the per-file reporter', { skip: !isGitRepo && 'requires a git checkout' }, function(t, done) {
+	var tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'plato-untracked-'));
+	var tmpFile = path.join(tmpDir, 'untracked.js');
+	fs.writeFileSync(tmpFile, 'function add(a, b) { return a + b; }\nmodule.exports = add;\n');
+
+	t.after(function() {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	// gitPath points at a real git repo, but the analyzed file is not in
+	// that repo's history — getByPath throws and should be swallowed.
+	plato.inspect([tmpFile], null, { gitPath: projectRoot, projectRoot: projectRoot }, function(reports) {
+		assert.strictEqual(reports.length, 1);
+		assert.strictEqual(reports[0].churn, undefined, 'no churn expected for untracked file');
+		done();
+	});
+});
+
+test('explicit gitPath option still works as an override', { skip: !isGitRepo && 'requires a git checkout' }, function(t, done) {
+	plato.inspect([fixture], null, { gitPath: projectRoot }, function(reports) {
+		assert.strictEqual(reports.length, 1);
+		assert.ok(reports[0].churn, 'churn should be collected when gitPath is explicit');
+		assert.ok(reports[0].churn.changes > 0);
+		done();
+	});
+});


### PR DESCRIPTION
## Summary

- Defaults `gitPath` to `projectRoot` (which already defaults to `cwd`) so the "Churn vs Complexity" report populates without needing to pass `-g`.
- Wraps the `GitChurn` constructor in try/catch so non-git directories log a warning and continue, instead of crashing.
- Wraps the per-file `getByPath` lookup in try/catch so files outside git history (uncommitted, gitignored) don't abort analysis.

## Why

The README's documented command — `upjs-plato -r -d ./report src` — produces a report with a blank "Churn vs Complexity" chart, because churn collection was gated behind an undocumented `-g` flag. After this change, churn is collected automatically when the working directory is a git repo.

`-g` still works as an explicit override for cases where the analyzed source lives in a different git repo than the cwd (e.g. monorepos).

## Test plan

- [x] Run `./bin/plato -r -d ./report-self lib` from the project root — churn data is collected automatically (`total: 220` across 49 files), matching what `-g <root>` produced previously.
- [x] Run plato in a directory that isn't a git repo — a `Skipping churn collection ...` warning is logged and analysis completes successfully with `total churn: 0`, no crash.
- [x] Confirm `-g` still works as an explicit override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)