### PR TITLE
Slim the published tarball with a files allowlist

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,0 @@
-/node_modules/
-.idea
-reports/

--- a/package.json
+++ b/package.json
@@ -24,6 +24,11 @@
   "bin": "bin/plato",
   "license": "MIT",
   "main": "lib/plato",
+  "files": [
+    "bin/",
+    "lib/",
+    "LICENSE-MIT"
+  ],
   "engines": {
     "node": ">= 18.0.0"
   },


### PR DESCRIPTION
## Summary

Replace the sparse `.npmignore` (which only excluded `node_modules/`, `.idea`, and `reports/`) with an explicit `files` allowlist in `package.json`. Modern best practice: opt in to what ships rather than enumerate what shouldn't.

## Results from `npm pack --dry-run`

|              | Before | After    | Change |
|--------------|-------:|---------:|-------:|
| Files        |    707 |       75 |   −89% |
| Packed size  | 4.6 MB |   588 KB |   −87% |
| Unpacked size| 35.6 MB|   1.7 MB |   −95% |

## What was shipping that shouldn't

- `.claude/settings.local.json` — local Claude Code settings (oops)
- `.editorconfig`, `.eslintrc`, `.gitattributes` — repo dev metadata
- `.github/workflows/ci.yml` — CI config
- The entire `test/` directory: nodeunit-style tests, dead CasperJS browser tests (`casper-*.js`), fixtures, `model_history.json`

## What still ships

- `bin/` — the CLI entry
- `lib/` — runtime code, including `assets/` (CSS, JS bundles, vendor libs, fonts) and `templates/` that the HTML report serves
- `LICENSE-MIT` — listed explicitly because npm's auto-include matches `LICENSE` / `LICENCE` exactly but not hyphenated variants
- `README.md`, `package.json`, and `CHANGELOG.md` (once #9 lands) are auto-included by npm

## Notes

I verified nothing in `lib/` references files outside `lib/` (only `../../util` from `lib/reporters/dependencies/*` which resolves to `lib/util.js`).

## Test plan

- [x] `npm pack --dry-run` shows 75 files / 588 KB packed.
- [x] All runtime assets (`lib/assets/scripts/bundles/core-bundle.js`, `lib/templates/*.html`, `lib/cli/options.json`) are still present.
- [x] `LICENSE-MIT` is in the tarball.
- [ ] After publish, smoke-test `npx upjs-plato@2.0.0 -r -d /tmp/r lib` from a clean checkout — confirms the slimmed package still produces a working report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)