### PR TITLE
Explore: Node 12-20 compatibility in CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        node: [16, 18, 22, 24]
+        node: [18, 22, 24]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        node: [22, 24]
+        node: [16, 18, 22, 24]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -27,4 +27,14 @@ jobs:
 
       - run: yarn install --frozen-lockfile
 
-      - run: yarn test:coverage
+      # Coverage flags require Node >= 22 (--test-coverage-exclude landed in
+      # 22.10 and was not backported). For Node 16 / 18 run plain tests so
+      # the job reports actual library compatibility rather than failing at
+      # the unknown flag.
+      - name: Run tests
+        run: |
+          if [ "${{ matrix.node }}" = "22" ] || [ "${{ matrix.node }}" = "24" ]; then
+            yarn test:coverage
+          else
+            yarn test
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        node: [18, 22, 24]
+        node: [18, 20, 22, 24]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,9 @@ The next release, currently `2.0.0` in `package.json`, will collect the work mer
 
 ### Infrastructure
 
-- Replaced the non-functional Travis CI config with a GitHub Actions workflow. CI now runs on Ubuntu and macOS across Node 16, 18, 22, and 24. ([#8](https://github.com/upgradejs/upjs-plato/pull/8), [#12](https://github.com/upgradejs/upjs-plato/pull/12), [#13](https://github.com/upgradejs/upjs-plato/pull/13))
+- Replaced the non-functional Travis CI config with a GitHub Actions workflow. CI now runs on Ubuntu and macOS across Node 18, 22, and 24. ([#8](https://github.com/upgradejs/upjs-plato/pull/8), [#12](https://github.com/upgradejs/upjs-plato/pull/12), [#13](https://github.com/upgradejs/upjs-plato/pull/13))
 - Code coverage is reported on every CI run on Node 22+ (where `--test-coverage-exclude` is available), using Node's built-in `--experimental-test-coverage` flag. ([#12](https://github.com/upgradejs/upjs-plato/pull/12), [#13](https://github.com/upgradejs/upjs-plato/pull/13))
-- `engines.node` set to `>= 16.0.0` (was `>= 0.10.0`) to honestly reflect the supported range. ([#8](https://github.com/upgradejs/upjs-plato/pull/8), [#13](https://github.com/upgradejs/upjs-plato/pull/13))
+- `engines.node` set to `>= 18.0.0` (was `>= 0.10.0`) to honestly reflect the supported range. Node 16 was investigated but blocked by a transitive `yarn-audit-html` engine requirement. ([#8](https://github.com/upgradejs/upjs-plato/pull/8), [#13](https://github.com/upgradejs/upjs-plato/pull/13))
 - `npm test` now runs `node --test test/*_test.js` (built-in test runner, no new dependencies) instead of the previous TODO placeholder. ([#8](https://github.com/upgradejs/upjs-plato/pull/8))
 - Published tarball trimmed from 707 files / 4.6 MB to 75 files / 588 KB via a `files` allowlist in `package.json`. Dev-only files (`.github/`, `test/`, `.editorconfig`, etc.) are no longer shipped. ([#11](https://github.com/upgradejs/upjs-plato/pull/11))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ The next release, currently `2.0.0` in `package.json`, will collect the work mer
 
 ### Infrastructure
 
-- Replaced the non-functional Travis CI config with a GitHub Actions workflow. CI now runs on Ubuntu and macOS across Node 18, 22, and 24. ([#8](https://github.com/upgradejs/upjs-plato/pull/8), [#12](https://github.com/upgradejs/upjs-plato/pull/12), [#13](https://github.com/upgradejs/upjs-plato/pull/13))
+- Replaced the non-functional Travis CI config with a GitHub Actions workflow. CI now runs on Ubuntu and macOS across Node 18, 20, 22, and 24. ([#8](https://github.com/upgradejs/upjs-plato/pull/8), [#12](https://github.com/upgradejs/upjs-plato/pull/12), [#13](https://github.com/upgradejs/upjs-plato/pull/13))
 - Code coverage is reported on every CI run on Node 22+ (where `--test-coverage-exclude` is available), using Node's built-in `--experimental-test-coverage` flag. ([#12](https://github.com/upgradejs/upjs-plato/pull/12), [#13](https://github.com/upgradejs/upjs-plato/pull/13))
 - `engines.node` set to `>= 18.0.0` (was `>= 0.10.0`) to honestly reflect the supported range. Node 16 was investigated but blocked by a transitive `yarn-audit-html` engine requirement. ([#8](https://github.com/upgradejs/upjs-plato/pull/8), [#13](https://github.com/upgradejs/upjs-plato/pull/13))
 - `npm test` now runs `node --test test/*_test.js` (built-in test runner, no new dependencies) instead of the previous TODO placeholder. ([#8](https://github.com/upgradejs/upjs-plato/pull/8))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,11 @@ The next release, currently `2.0.0` in `package.json`, will collect the work mer
 
 ### Infrastructure
 
-- Replaced the non-functional Travis CI config with a GitHub Actions workflow running on Ubuntu and macOS across Node 20, 22, and 24. ([#8](https://github.com/upgradejs/upjs-plato/pull/8))
-- `engines.node` bumped from `>= 0.10.0` to `>= 18.0.0` to match what the codebase actually requires. ([#8](https://github.com/upgradejs/upjs-plato/pull/8))
+- Replaced the non-functional Travis CI config with a GitHub Actions workflow. CI now runs on Ubuntu and macOS across Node 16, 18, 22, and 24. ([#8](https://github.com/upgradejs/upjs-plato/pull/8), [#12](https://github.com/upgradejs/upjs-plato/pull/12), [#13](https://github.com/upgradejs/upjs-plato/pull/13))
+- Code coverage is reported on every CI run on Node 22+ (where `--test-coverage-exclude` is available), using Node's built-in `--experimental-test-coverage` flag. ([#12](https://github.com/upgradejs/upjs-plato/pull/12), [#13](https://github.com/upgradejs/upjs-plato/pull/13))
+- `engines.node` set to `>= 16.0.0` (was `>= 0.10.0`) to honestly reflect the supported range. ([#8](https://github.com/upgradejs/upjs-plato/pull/8), [#13](https://github.com/upgradejs/upjs-plato/pull/13))
 - `npm test` now runs `node --test test/*_test.js` (built-in test runner, no new dependencies) instead of the previous TODO placeholder. ([#8](https://github.com/upgradejs/upjs-plato/pull/8))
+- Published tarball trimmed from 707 files / 4.6 MB to 75 files / 588 KB via a `files` allowlist in `package.json`. Dev-only files (`.github/`, `test/`, `.editorconfig`, etc.) are no longer shipped. ([#11](https://github.com/upgradejs/upjs-plato/pull/11))
 
 ## [1.3.1] - 2023-05-16
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ This project is a fork of [es6-plato](https://github.com/the-simian/es6-plato)
 
 ## Requirements
 
-`upjs-plato` requires **Node.js 16 or later**. CI verifies the package on Node 16, 18, 22, and 24 across Ubuntu and macOS. Code coverage is reported on Node 22+ where the relevant test-runner flags are available.
+`upjs-plato` requires **Node.js 18 or later**. CI verifies the package on Node 18, 22, and 24 across Ubuntu and macOS. Code coverage is reported on Node 22+ where the relevant test-runner flags are available.
+
+Node 16 was considered but is blocked by a transitive dependency (`yarn-audit-html`) that requires Node 18+.
 
 # The Report
 ![dank-es6-nugs](https://cloud.githubusercontent.com/assets/954596/18904556/3a81efea-8524-11e6-8588-ad8f5a51b001.PNG)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ Based on the older es5 plato, this is a port to `es6` and `eslint`
 
 This project is a fork of [es6-plato](https://github.com/the-simian/es6-plato)
 
+## Requirements
+
+`upjs-plato` requires **Node.js 16 or later**. CI verifies the package on Node 16, 18, 22, and 24 across Ubuntu and macOS. Code coverage is reported on Node 22+ where the relevant test-runner flags are available.
+
 # The Report
 ![dank-es6-nugs](https://cloud.githubusercontent.com/assets/954596/18904556/3a81efea-8524-11e6-8588-ad8f5a51b001.PNG)
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This project is a fork of [es6-plato](https://github.com/the-simian/es6-plato)
 
 ## Requirements
 
-`upjs-plato` requires **Node.js 18 or later**. CI verifies the package on Node 18, 22, and 24 across Ubuntu and macOS. Code coverage is reported on Node 22+ where the relevant test-runner flags are available.
+`upjs-plato` requires **Node.js 18 or later**. CI verifies the package on Node 18, 20, 22, and 24 across Ubuntu and macOS. Code coverage is reported on Node 22+ where the relevant test-runner flags are available.
 
 Node 16 was considered but is blocked by a transitive dependency (`yarn-audit-html`) that requires Node 18+.
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "LICENSE-MIT"
   ],
   "engines": {
-    "node": ">= 16.0.0"
+    "node": ">= 18.0.0"
   },
   "scripts": {
     "test": "node --test test/*_test.js",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "LICENSE-MIT"
   ],
   "engines": {
-    "node": ">= 22.0.0"
+    "node": ">= 16.0.0"
   },
   "scripts": {
     "test": "node --test test/*_test.js",


### PR DESCRIPTION
## Summary

Adds Node `12, 14, 16, 18, 20` to the existing matrix to find out empirically where the library and tests still run vs. where they break.

**Intended as temporary** — once we have the data, trim back to supported versions (or move to a `workflow_dispatch`-only workflow). Stacked on top of #12.

## Coverage flag handling

`yarn test:coverage` uses `--test-coverage-exclude`, which is Node 22+ only. For Node < 22, the workflow falls back to `yarn test` so the job reports library compatibility rather than failing at an unknown flag.

## Predictions before the run

- **Node 12, 14, 16**: should fail. `node:test` doesn't exist before Node 18. The legacy `*_test.js` files require `node:test` via `node --test`; the test runner flag itself is unknown to old Node.
- **Node 18, 20**: should pass tests if dependencies install. Both support `node --test`.
- **Node 22, 24**: same as before.
- **macOS arm64**: older Node versions may have no arm64 binary in `setup-node@v4`'s manifest, in which case those jobs fail at setup. That's still useful data ("don't bother with macOS arm64 below Node X").

## What we'll learn

- Which Node lines can install the dependency tree (`eslint 8`, `@babel/core 7`, etc.).
- Which can load `lib/plato.js` and friends (might fail on optional chaining, top-level await, etc. depending on the line).
- The actual support floor.

## Test plan

- [ ] CI runs all 14 matrix entries.
- [ ] Use the pass/fail breakdown to decide:
  - Keep `engines.node >= 22` (current).
  - Lower it (e.g., to 18) if Node 18/20 jobs pass.
  - Revert this PR if results are already known.

🤖 Generated with [Claude Code](https://claude.com/claude-code)